### PR TITLE
docs: add .ai-review/instructions.md for repo-specific review context

### DIFF
--- a/.ai-review/instructions.md
+++ b/.ai-review/instructions.md
@@ -1,0 +1,116 @@
+# Reviewing xrpl-rust
+
+xrpl-rust is the canonical **Rust SDK for the XRP Ledger** (crate `xrpl` + the
+`xrpl-rust-macros` proc-macro crate), **no_std-first**. It is a **financial primitive**: amount,
+serialization, and signing bugs corrupt transactions or break consensus compatibility, and
+surface only on-ledger. **rippled is the source of truth** — verify wire shapes against it,
+not idiomatic serde design.
+
+## Amounts & numbers
+- Amount values are `Cow<'a, str>` strings, never numeric fields. XRPAmount's `get_errors`/
+  `TryInto<u32>` parse drops as **u32 — a known-bad precedent** rejecting amounts > ~4,294 XRP;
+  flag new drops code copying it; use u64/BigDecimal.
+- `From<f64>` is unit-asymmetric: `Amount::from(f64)` = **XRP** (×1e6); `XRPAmount::from(f64)` =
+  verbatim **drops** — wrong constructor = silent 1e6 error.
+- Both decimal crates are deliberate: `rust_decimal` for XRP/drops (utils only), **BigDecimal
+  for IOU** (IOU exponents −96..80 exceed it). Don't consolidate; no rust_decimal/f64 in new IOU paths.
+- `Amount` deserialization is hand-written exact-key-set dispatch (MPT = exactly `{mpt_issuance_id,
+  value}` first, IOU = exactly 3 keys, XRP string last); `deny_unknown_fields` on the amount
+  structs is **load-bearing** too. Don't flag it (xrpl.js parity); DO flag relaxing it or field
+  additions that skip the key-count guards in `amount/mod.rs`.
+
+## Binary codec
+- Round-trip plus **byte-exact xrpl.js reference vectors are the spec**. A new SerializedType needs
+  **three registration arms** in `types/mod.rs` (XRPLTypes enum, `from_value` match,
+  `From<XRPLTypes>`) — unregistered types fail only at runtime.
+- `BinaryParser::read(n)` **panics** on truncated input — validate wire-derived lengths first.
+  Every field decode must **consume exactly the field's bytes or Err**; `Ok` without
+  advancing corrupts every later field.
+- Canonical ordinal sort and signing-field filtering happen ONLY in `STObject::try_from_value`
+  — flag encode paths calling `write_field_and_value` directly, bypassing `serialize_json`.
+- UInt64 strings are **hex by default**; only `BASE10_UINT64_FIELDS` (MaximumAmount,
+  OutstandingAmount, MPTAmount, LockedAmount) are base-10. Don't flag the asymmetry (xrpl.js
+  parity); DO flag a new decimal-string u64 field not added there — it misparses as hex.
+- IOU Amount encoding **rounds underflow to canonical zero** (0x8000…) and errors on overflow
+  — spec, not precision loss. Mantissa/exponent math has a fixed-bug history (unsigned_abs sign
+  loss, IOU sign inversion): changes need exponent-boundary and zero-crossing
+  tests; range-check wire-read integers where overflow is possible (panics debug builds).
+
+## definitions.json
+- **No generator**: `definitions.json` is a manual copy synced from xrpl.js/rippled, embedded via
+  `include_str!`. Hand-edits are normal here; drift from upstream is the finding.
+- A FIELDS entry whose `"type"` is missing from TYPES **panics the whole codec** at first use; a new
+  TYPES name needs an `XRPLTypes::from_value` arm; model support for new tx/ledger-entry types
+  needs variants in the **hardcoded** `TransactionType`/`LedgerEntryType` enums.
+
+## Transaction models
+- New tx type = model file + `pub mod` + `TransactionType` variant, whose **name IS the wire
+  string** (plain serde, no renames): exact rippled casing (NFTokenMint, DIDSet) or it
+  serializes wrong with no compile error.
+- Struct shape: `#[skip_serializing_none]` + PascalCase rename + flattened `CommonFields<'a,
+  FlagEnum>`. Acronym fields need explicit renames (`AccountTxnID`, `URI`) — a missing rename
+  round-trips against itself but **rippled rejects it**.
+- Flags are `#[repr(u32)]` serde_repr enums in `FlagCollection` (wire = one u32 bitmask); `EnumIter`
+  is load-bearing for decoding. Flagless txs use `NoFlags`.
+- Models deriving `ValidateCurrencies` must chain `self.validate_currencies()` in
+  `get_errors()` — the derive **generates the method but nothing calls it**. It matches type
+  names **textually** (six names, bare `Option<T>` only): aliases, `Vec<Amount>`, or new types
+  are silently skipped — flag amount/currency fields typed outside the six.
+
+## Cryptography & signing
+- The algorithm is inferred **only from encoding prefixes** (seed `sEd…` → ed25519, `s…` →
+  secp256k1; key prefix `ED` vs zero-padding); `generate_seed` defaults to ED25519. Prefix/format
+  changes silently derive a **different address from the same entropy**.
+- Prehash asymmetry is spec: secp256k1 signs `sha512_first_half(msg)`, ed25519 signs the raw
+  message. RFC-6979 and low-S output come from the secp256k1 crate defaults —
+  no canonicalization code is "missing".
+- Key material comes from **OsRng/thread_rng only** (a seedable PRNG was a fixed vuln). Error variants
+  must never capture secret bytes (Debug-formatting dumps them); long-lived key holders follow
+  Wallet: zeroize-on-Drop + redacting Debug.
+- Multisigning: 4-byte prefixes (STX/SMT/CLM/BCH) domain-separate payloads + the signer's
+  decoded-AccountId suffix; the combined tx gets `SigningPubKey: ""` (present, empty);
+  `Signers` sort by **decoded AccountId bytes**, not base58 strings.
+- `sign(tx, wallet, true)` **replaces** the Signers array (despite its doc comment);
+  `multisign()` reads only the first signer per entry: one tx clone per signer. Flag repeated
+  `sign(.., true)` on one object, and autofill-then-multisign without `signers_count` or an
+  explicit fee (underpays the fee).
+- `autofill` fills only-when-None; **mainnet gets no NetworkID** (id > 1024 gate) —
+  intentional. `submit_and_wait` unconditionally unwraps `last_ledger_sequence` — flag
+  non-autofill callers without it preset.
+
+## Clients & results (tolerant)
+- Result models must deserialize **real rippled responses**: no `deny_unknown_fields` (and broken in
+  `#[serde(flatten)]` chains), `Option` for non-guaranteed fields, and
+  `serde_json::Value` for unstable sections.
+- `XRPLResult` is untagged and **order-dependent** (`Other` stays before Subscribe/Ping); the
+  `TryFrom` re-parse-from-`Other` fallbacks are deliberate, not dead code; new variants must
+  respect ordering and add a fallback when mis-routable.
+- Clients return `Ok` on rippled app errors; `try_into::<XRPLResult>()` does the status check —
+  don't flag "missing error handling" at `request_impl`.
+
+## Sync/async parity
+- `src/{account,ledger,transaction,wallet}` sync helpers are pure `embassy_futures::block_on`
+  facades over `async_`-aliased imports from `src/asynch/` — signatures and lifetimes
+  hand-duplicated, **no parity check**. Flag one-sided signature edits and logic in a wrapper —
+  behavior lives async-side only. Embassy's `block_on` is the no_std-correct choice, not tokio's.
+
+## no_std & features
+- Library code imports `String`/`Vec`/`format` from `alloc::` and the rest from `core::`, never
+  `std::` (std only under `cfg(feature = "std")` or in tests). `extern crate std as alloc`
+  in std builds is intentional — don't flag it.
+- `crate::_serde::HashMap` (hashbrown) for hash maps in model/serde code; IndexMap where
+  insertion order matters.
+  Errors derive `thiserror_no_std::Error`, never `thiserror`.
+- New std-defaulting non-optional deps: `default-features = false` (+ `alloc`), std via the
+  `[features] std` list; std-only deps stay `optional = true`.
+
+## Test conventions (do NOT flag)
+- `snoPBrXtMeMyMHUVTgbuqAfg1SUTb` / `rHb9…` are the standalone-node genesis credentials,
+  intentionally committed. Manual `ledger_accept()`, the close-time poll, `--test-threads=1`,
+  and the blockchain lock are required by the shared standalone `xrpld` node.
+- Opaque hex vectors annotated as xrpl.js ports ARE the spec — never simplify or regenerate.
+  Shared fixtures live in `tests/common/constants.rs`; one-off literals with an inline
+  decode comment are accepted style.
+
+## Contributor conventions
+- Breaking serde/public-API changes need a CHANGELOG entry (prefer `**Breaking:**`).

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+
+# Short steer toward useful feedback for open-source contributors; skip style nits (max 250 chars).
+tone_instructions: "Be concise and encouraging to open-source contributors. Flag correctness, security, and API-contract issues; skip style and formatting nits."
+
+reviews:
+  # chill = fewer, higher-signal comments (assertive is nitpicky).
+  profile: "chill"
+  # Keep the bot's review non-blocking; don't gate a contributor's merge on nitpicks.
+  request_changes_workflow: false
+  # Don't let the bot append a summary to the contributor's PR description.
+  high_level_summary: false
+  # poem is noise.
+  poem: false
+  # "Fortune" text while reviewing is noise.
+  in_progress_fortune: false
+  # Post a status note (incl. when a review is skipped).
+  review_status: true
+  # Walkthrough shown expanded (matches existing xrpl.js choice).
+  collapse_walkthrough: false
+  # Auto sequence diagrams are low-value filler on SDK PRs.
+  sequence_diagrams: false
+  # Cancel an in-progress review if the PR closes/merges.
+  abort_on_close: true
+  # Flag spam / low-effort PRs on public repos.
+  slop_detection:
+    enabled: true
+  auto_review:
+    # Auto-review every PR.
+    enabled: true
+    # Don't review drafts contributors are still iterating on.
+    drafts: false
+    # Skip dependency/release bumps.
+    ignore_title_keywords:
+      - "build("
+  tools:
+    # Grammar/spell nits on comments and prose are false-positive noise.
+    languagetool:
+      enabled: false
+
+chat:
+  # Let contributors ask follow-ups without @-mentioning the bot.
+  auto_reply: true
+  # No ASCII/emoji art.
+  art: false
+  # Required for external (non-org) contributors to interact with the bot.
+  allow_non_org_members: true
+
+knowledge_base:
+  # Give the bot our XRPL-specific review grounding.
+  # applyTo: "**" makes .ai-review/instructions.md apply repo-wide (a guideline file
+  # otherwise scopes only to its own directory).
+  code_guidelines:
+    filePatterns:
+      - files: ".ai-review/instructions.md"
+        applyTo: "**"


### PR DESCRIPTION
## Summary

Adds a `.ai-review/instructions.md` file that the AI code reviewer reads before reviewing a pull request. It gives the reviewer context about how this crate actually works, so its comments reflect xrpl-rust's real conventions instead of generic Rust advice. This is a review-guidance file only: it changes no code and no runtime behavior, and it does not affect CI or block merges.

## Why

The reviewer is general-purpose. Without repo context it tends to miss the pitfalls specific to a financial SDK and, worse, flag intentional idioms as if they were bugs. This file encodes what a new senior reviewer would need to know before commenting on xrpl-rust, for example:

- Amount values are strings (XRP amounts are integer drop strings), and the two decimal crates in the tree have a deliberate division of labor.
- `definitions.json` has no generator: it is hand-synced from xrpl.js/rippled, so fidelity to upstream is what needs checking, not the hand-edit itself.
- The crate is no_std-first: library code imports from `alloc`/`core`, and the`extern crate std as alloc` alias is intentional, not a typo.
- The sync helper modules are hand-maintained wrappers over the async implementation with no automated parity check, so one-sided edits drift silently.
- Result models are deliberately tolerant of unknown fields from rippled, while the amount structs are deliberately strict; both directions look wrong to a generic reviewer.
- Signing has XRPL-specific rules (prefix-based key algorithm inference, multisign signer ordering by decoded bytes) where a wrong value fails only on-ledger.

It also tells the reviewer which patterns are deliberate and should not be flagged (the standalone-node genesis credentials in tests, manual ledger advancement, test vectors ported byte-for-byte from xrpl.js).

## What's in it

A short, high-signal list grouped by area:

- Amounts and numbers
- Binary codec
- definitions.json
- Transaction models
- Cryptography and signing
- Clients and results
- Sync/async parity
- no_std and features
- Test conventions (idioms not to flag)
- Contributor conventions

The file is intentionally small so it fits the reviewer's context budget.

## How it was built and checked

- Derived from a scan of the codebase plus a review of what human reviewers have historically commented on in xrpl-rust pull requests.
- Every rule was validated against the current code on `main`: each cited file and symbol was opened and confirmed.
- A separate verification pass then re-checked each rule for accuracy and for false-positive safety (would a reviewer applying it literally flag correct code?), with an independent second review confirming each change. Rules that could cause false positives were narrowed, using counter-examples from this repo's own code and tests.

## Notes for reviewers

- This is guidance, not policy. You can edit it through the normal PR process, and the reviewer will pick up the change.
- No package behavior changes, so no CHANGELOG entry is included.
- This follows the same approach as the equivalent file for xrpl.js and xrpl-py, so review guidance stays consistent across the XRPL SDKs.
