### PR TITLE
Sync definitions.json with rippled ripple/se/supported

### DIFF
--- a/src/core/binarycodec/definitions/definitions.json
+++ b/src/core/binarycodec/definitions/definitions.json
@@ -929,6 +929,56 @@
       }
     ],
     [
+      "GasLimit",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 75,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "BytecodeSizeLimit",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 76,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "GasPrice",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 77,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "Gas",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 78,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "GasUsed",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 79,
+        "type": "UInt32"
+      }
+    ],
+    [
       "IndexNext",
       {
         "isSerialized": true,
@@ -2399,6 +2449,16 @@
       }
     ],
     [
+      "Bytecode",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 47,
+        "type": "Blob"
+      }
+    ],
+    [
       "Account",
       {
         "isSerialized": true,
@@ -2835,6 +2895,16 @@
         "isSigningField": true,
         "isVLEncoded": false,
         "nth": 1,
+        "type": "Int32"
+      }
+    ],
+    [
+      "VMReturnCode",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 2,
         "type": "Int32"
       }
     ],
@@ -4365,6 +4435,14 @@
         "optionality": 1
       },
       {
+        "name": "Bytecode",
+        "optionality": 1
+      },
+      {
+        "name": "Data",
+        "optionality": 1
+      },
+      {
         "name": "SourceTag",
         "optionality": 1
       },
@@ -4424,6 +4502,18 @@
       },
       {
         "name": "ReserveIncrementDrops",
+        "optionality": 1
+      },
+      {
+        "name": "GasLimit",
+        "optionality": 1
+      },
+      {
+        "name": "BytecodeSizeLimit",
+        "optionality": 1
+      },
+      {
+        "name": "GasPrice",
         "optionality": 1
       },
       {
@@ -5408,14 +5498,14 @@
     },
     "MPTokenIssuanceSet": {
       "tfMPTLock": 1,
+      "tfMPTUnlock": 2,
       "tfMPTSetCanClawback": 128,
       "tfMPTSetCanEscrow": 16,
       "tfMPTSetCanHoldConfidentialBalance": 256,
       "tfMPTSetCanLock": 4,
       "tfMPTSetCanTrade": 32,
       "tfMPTSetCanTransfer": 64,
-      "tfMPTSetRequireAuth": 8,
-      "tfMPTUnlock": 2
+      "tfMPTSetRequireAuth": 8
     },
     "NFTokenCreateOffer": {
       "tfSellNFToken": 1
@@ -5978,6 +6068,10 @@
         "optionality": 0
       },
       {
+        "name": "DestinationTag",
+        "optionality": 1
+      },
+      {
         "name": "Amount",
         "optionality": 0
       },
@@ -5994,7 +6088,11 @@
         "optionality": 1
       },
       {
-        "name": "DestinationTag",
+        "name": "Bytecode",
+        "optionality": 1
+      },
+      {
+        "name": "Data",
         "optionality": 1
       }
     ],
@@ -6017,6 +6115,10 @@
       },
       {
         "name": "CredentialIDs",
+        "optionality": 1
+      },
+      {
+        "name": "Gas",
         "optionality": 1
       }
     ],
@@ -6584,6 +6686,18 @@
       {
         "name": "ReserveIncrementDrops",
         "optionality": 1
+      },
+      {
+        "name": "GasLimit",
+        "optionality": 1
+      },
+      {
+        "name": "BytecodeSizeLimit",
+        "optionality": 1
+      },
+      {
+        "name": "GasPrice",
+        "optionality": 1
       }
     ],
     "SetRegularKey": [
@@ -7050,6 +7164,7 @@
     "tecARRAY_TOO_LARGE": 191,
     "tecBAD_CREDENTIALS": 193,
     "tecBAD_PROOF": 199,
+    "tecBYTECODE_REJECTED": 202,
     "tecCANT_ACCEPT_OWN_NFTOKEN_OFFER": 158,
     "tecCLAIM": 100,
     "tecCRYPTOCONDITION_ERROR": 146,
@@ -7093,6 +7208,7 @@
     "tecNO_SUITABLE_NFTOKEN_PAGE": 155,
     "tecNO_TARGET": 138,
     "tecOBJECT_NOT_FOUND": 160,
+    "tecOUT_OF_GAS": 201,
     "tecOVERSIZE": 145,
     "tecOWNERS": 132,
     "tecPATH_DRY": 128,
@@ -7132,6 +7248,7 @@
     "tefBAD_PATH_COUNT": -176,
     "tefBAD_QUORUM": -185,
     "tefBAD_SIGNATURE": -186,
+    "tefBYTECODE_NOT_INCLUDED": -174,
     "tefCREATED": -194,
     "tefEXCEPTION": -193,
     "tefFAILURE": -199,
@@ -7143,6 +7260,7 @@
     "tefNFTOKEN_IS_NOT_TRANSFERABLE": -179,
     "tefNOT_MULTI_SIGNING": -184,
     "tefNO_AUTH_REQUIRED": -191,
+    "tefNO_BYTECODE": -175,
     "tefNO_DST_PARTIAL": -177,
     "tefNO_TICKET": -180,
     "tefPAST_SEQ": -190,
@@ -7194,6 +7312,7 @@
     "temBAD_TICK_SIZE": -269,
     "temBAD_TRANSFER_FEE": -251,
     "temBAD_TRANSFER_RATE": -280,
+    "temBAD_WASM": -247,
     "temBAD_WEIGHT": -270,
     "temCANNOT_PREAUTH_SELF": -267,
     "temDISABLED": -273,
@@ -7202,6 +7321,7 @@
     "temEMPTY_DID": -254,
     "temINVALID": -277,
     "temINVALID_ACCOUNT_ID": -268,
+    "temINVALID_BYTECODE": -246,
     "temINVALID_COUNT": -266,
     "temINVALID_FLAG": -276,
     "temINVALID_INNER_BATCH": -250,
@@ -7209,6 +7329,7 @@
     "temREDUNDANT": -275,
     "temRIPPLE_EMPTY": -274,
     "temSEQ_AND_TICKET": -263,
+    "temTEMP_DISABLED": -245,
     "temUNCERTAIN": -265,
     "temUNKNOWN": -264,
     "temXCHAIN_BAD_PROOF": -259,
@@ -7353,6 +7474,5 @@
     "Validation": 10003,
     "Vector256": 19,
     "XChainBridge": 25
-  },
-  "hash": "8EB5E0E1DCEC6C6AAD9BB299B58DD4FF88A6D8F6982813E943BC9931B4E7A2AA"
+  }
 }


### PR DESCRIPTION
Refreshes the binary-codec definitions file to match the current state
of rippled's `ripple/se/supported` branch, obtained from the
`ripple-binary-codec@2.9.0-smartescrow.0` npm release (which packages
the smart-escrow-branch `server_definitions` output for JS SDKs; xrpl-rust
consumes the same shape).

This is a routine data-file update — no code changes. Brings in the
new wire fields, transaction templates, and result codes rippled has
added since the last manual sync. The +7 FIELDS all correspond to
XLS-100 Smart Escrows (7 UInt32 controllers + one Blob for bytecode +
one Int32 return code); typed model support for them lives in the
follow-up PR (EscrowCreate.bytecode/data + EscrowFinish.gas).

Additions
=========

FIELDS (+7):
  GasLimit (UInt32, nth=75), BytecodeSizeLimit (UInt32, nth=76),
  GasPrice (UInt32, nth=77), Gas (UInt32, nth=78),
  GasUsed (UInt32, nth=79), Bytecode (Blob VL, nth=47),
  VMReturnCode (Int32, nth=2)

TRANSACTION_RESULTS (+7):
  tecOUT_OF_GAS = 201
  tecBYTECODE_REJECTED = 202
  tefBYTECODE_NOT_INCLUDED = -174
  tefNO_BYTECODE = -175
  temTEMP_DISABLED = -245
  temINVALID_BYTECODE = -246
  temBAD_WASM = -247

TRANSACTION_FORMATS: EscrowCreate gains Bytecode + Data (optional);
EscrowFinish gains Bytecode, Data, Gas (optional).

Reconciliation with mainline
============================

The `ripple/se/supported` branch is a topic branch and lags mainline
on some MPT (XLS-33) features. To avoid regressing xrpl-rust's mainline
MPT support, the following flags present on mainline but absent from
the smart-escrow branch have been PRESERVED verbatim from the previous
definitions.json:

  TRANSACTION_FLAGS.MPTokenIssuanceSet:
    tfMPTSetCanClawback (128)
    tfMPTSetCanEscrow (16)
    tfMPTSetCanHoldConfidentialBalance (256)
    tfMPTSetCanLock (4)
    tfMPTSetCanTrade (32)
    tfMPTSetCanTransfer (64)
    tfMPTSetRequireAuth (8)

When the smart-escrow amendment merges into rippled's develop and
these MPT flags return via server_definitions, the next straight sync
becomes uneventful.

Note on the `hash` field: rippled's server_definitions output includes
a `hash` (definitions checksum) alongside the payload; when the file
is regenerated by any means, that hash changes accordingly. The
JS SDK release we sourced from strips `status` but preserves `hash`,
which matches xrpl-rust's file convention.

Sourcing recipe (for future refreshes):

    curl -sL https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-<version>.tgz | \
      tar -xzOf - package/src/enums/definitions.json > definitions.json

OR against a local rippled on the smart-escrow branch:

    curl -s -X POST http://localhost:5005/ \
      -H 'Content-Type: application/json' \
      -d '{"method": "server_definitions"}' \
      | jq '.result | del(.status)' \
      > src/core/binarycodec/definitions/definitions.json

Related: xrpl-py auto-generates this file per-PR via a rippled CI
artifact (see XRPLF/rippled#6858).

